### PR TITLE
Fix bug where mousedown/touchstart inside the child, then mouseup/touchend outside the child doesn't reset the insideClick flag.

### DIFF
--- a/src/PageClick.js
+++ b/src/PageClick.js
@@ -27,8 +27,10 @@ const PageClick = React.createClass({
 
 
   componentDidMount() {
-    global.window.addEventListener('mousedown', this.onDocumentClick, false);
     global.window.addEventListener('touchstart', this.onDocumentClick, false);
+    global.window.addEventListener('touchend', this.onDocumentMouseUp, false);
+    global.window.addEventListener('mousedown', this.onDocumentClick, false);
+    global.window.addEventListener('mouseup', this.onDocumentMouseUp, false);
   },
 
 
@@ -36,8 +38,10 @@ const PageClick = React.createClass({
 
 
   componentWillUnmount() {
-    global.window.removeEventListener('mousedown', this.onDocumentClick, false);
     global.window.removeEventListener('touchstart', this.onDocumentClick, false);
+    global.window.removeEventListener('touchend', this.onDocumentMouseUp, false);
+    global.window.removeEventListener('mousedown', this.onDocumentClick, false);
+    global.window.removeEventListener('mouseup', this.onDocumentMouseUp, false);
   },
 
 
@@ -46,6 +50,11 @@ const PageClick = React.createClass({
       return;
     }
     this.props.onClick(...args);
+  },
+
+
+  onDocumentMouseUp() {
+    this.insideClick = false;
   },
 
 
@@ -58,7 +67,6 @@ const PageClick = React.createClass({
 
 
   onMouseUp(...args) {
-    this.insideClick = false;
     if (this.props.onMouseUp) {
       this.props.onMouseUp(...args);
     }
@@ -74,7 +82,6 @@ const PageClick = React.createClass({
 
 
   onTouchEnd(...args) {
-    this.insideClick = false;
     if (this.props.onTouchEnd) {
       this.props.onTouchEnd(...args);
     }

--- a/src/PageClick.js
+++ b/src/PageClick.js
@@ -8,8 +8,6 @@ const PageClick = React.createClass({
     onClick: React.PropTypes.func.isRequired,
     onMouseDown: React.PropTypes.func,
     onTouchStart: React.PropTypes.func,
-    onMouseUp: React.PropTypes.func,
-    onTouchEnd: React.PropTypes.func,
     outsideOnly: React.PropTypes.bool
   },
 
@@ -66,13 +64,6 @@ const PageClick = React.createClass({
   },
 
 
-  onMouseUp(...args) {
-    if (this.props.onMouseUp) {
-      this.props.onMouseUp(...args);
-    }
-  },
-
-
   onTouchStart(...args) {
     this.insideClick = true;
     if (this.props.onTouchStart) {
@@ -81,19 +72,10 @@ const PageClick = React.createClass({
   },
 
 
-  onTouchEnd(...args) {
-    if (this.props.onTouchEnd) {
-      this.props.onTouchEnd(...args);
-    }
-  },
-
-
   render() {
     const props = this.props.outsideOnly ? {
       onMouseDown: this.onMouseDown,
-      onMouseUp: this.onMouseUp,
-      onTouchStart: this.onTouchStart,
-      onTouchEnd: this.onTouchEnd
+      onTouchStart: this.onTouchStart
     } : {};
 
     return React.cloneElement(React.Children.only(this.props.children), props);


### PR DESCRIPTION
### Changes

reset the `clickInside` flag on window mouse up and window touch end.